### PR TITLE
Added a function to allow for adding / updating a template.

### DIFF
--- a/elasticsearch-wrapper.js
+++ b/elasticsearch-wrapper.js
@@ -405,3 +405,29 @@ exports.config = function (_config) {
 
     return config;
 };
+
+/**
+ * Given a name and a template, it will save it to the es templates.
+ * For more info on how and why to use templates refer to the docs.
+ *
+ * @param {string} name name of the template.
+ * @param {string} template the json template as a string.
+ * @return {object} promise
+ */
+exports.createTemplate = function (name, template) {
+    var defer = q.defer();
+
+    client.indices.putTemplate({
+        name: name,
+        body: template
+    }, function (error, response) {
+        if (error) {
+            defer.reject(error);
+            return;
+        }
+
+        defer.resolve(response);
+    });
+
+    return defer.promise;
+};


### PR DESCRIPTION
Adding a simple wrapper to allow us to add or replace an existing "_template".

Example usage:

```
var config      = require('../config'),
    DB          = require('elasticsearch-wrapper'),

    fs          = require('fs'),
    name        = 'test_template',
    template    = fs.readFileSync('./templates/template.json', {
        encoding: 'utf8'
    });

DB.config(config);
DB.createTemplate(name, template);
```

Then to see it:

```
curl -XGET 'http://localhost:9200/_template/test_template?pretty=true'
```

Useful urls:
- http://www.elasticsearch.org/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-indices-puttemplate
- http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-templates.html
