### PR TITLE
If object has an id use it as the id of the saved value in elasticsearch...

### DIFF
--- a/elasticsearch-wrapper.js
+++ b/elasticsearch-wrapper.js
@@ -48,8 +48,8 @@ exports.post = function (data) {
             }
 
             data.forEach(function (item) {
-                var defer = q.defer(),
-                    options = null;
+                var params,
+                    defer = q.defer();
 
                 promises.push(defer.promise);
 
@@ -57,7 +57,7 @@ exports.post = function (data) {
                     item.createdAt = (new Date()).toISOString();
                 }
 
-                options = {
+                params = {
                     index: indexName,
                     type: typeName,
                     timestamp: (new Date()).toISOString(),
@@ -65,11 +65,11 @@ exports.post = function (data) {
                 };
 
                 if (item.id) {
-                    options.id = item.id
+                    params.id = item.id
                 }
 
                 client.create(
-                    options,
+                    params,
                     function (error, response) {
                         if (error) {
                             defer.reject(error);


### PR DESCRIPTION
This allows the object.id to override the _id of the object in elasticsearch.

I also did the "timestamp" in a slightly different way than the rest of the file as I feel it is cleaner. (If we approve this way, I will make another request to clean up all the other "style").
