### PR TITLE
The script will now exit instead of keeping a connection.

### DIFF
--- a/elasticsearch-wrapper.js
+++ b/elasticsearch-wrapper.js
@@ -400,7 +400,8 @@ exports.config = function (_config) {
     config = _config;
 
     client = new elasticsearch.Client({
-        host: config.db.url
+        host: config.db.url,
+        maxKeepAliveRequests: 1
     });
 
     return config;


### PR DESCRIPTION
If we don't have this value set, we must ctrl+c the script from running.

Clearly, later this should be an object but there is an issue for that:
https://github.com/FronterAS/elasticsearch-wrapper/issues/2
