### PR TITLE
Elasticsearch config uses log.

### DIFF
--- a/elasticsearch-wrapper.js
+++ b/elasticsearch-wrapper.js
@@ -566,7 +566,7 @@ exports.config = function (_config) {
     };
 
     if (config.db.logging) {
-        clientOptions.logging = config.db.logging;
+        clientOptions.log = config.db.logging;
     }
 
     client = new elasticsearch.Client(clientOptions);


### PR DESCRIPTION
Long term we might want to change the config object. For now, just
need this to show the logs :)
