### PR TITLE
Fix malformed results crashing the app

### DIFF
--- a/dist/elasticsearch-wrapper.js
+++ b/dist/elasticsearch-wrapper.js
@@ -26,7 +26,12 @@ var q = require('q'),
 
     adaptResult = function (result) {
         var _result = result.fields || result._source;
-        _result.id = result.id || result._id;
+
+        if (_result) {
+            _result.id = result.id || result._id;
+        } else {
+            _result = result; // assumes the result wasn't a document object
+        }
 
         return _result;
     },

--- a/elasticsearch-wrapper.js
+++ b/elasticsearch-wrapper.js
@@ -26,7 +26,12 @@ var q = require('q'),
 
     adaptResult = function (result) {
         var _result = result.fields || result._source;
-        _result.id = result.id || result._id;
+
+        if (_result) {
+            _result.id = result.id || result._id;
+        } else {
+            _result = result; // assumes the result wasn't a document object
+        }
 
         return _result;
     },


### PR DESCRIPTION
If `adaptResult` received an object which didn't have a `fields` or `_source` property, which could be the result of attempting to retrieve a document which doesn't exist, it would throw an error on line #29 which could crash the app.

This way it just sends the malformed through, letting whomever requested the document deal with it.
